### PR TITLE
🔧 Fix Render deployment port binding issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -607,10 +607,10 @@ if __name__ == '__main__':
     os.makedirs('static', exist_ok=True)
     os.makedirs('templates', exist_ok=True)
     
-    # Production-ready server configuration
-    host = os.environ.get('HOST', '127.0.0.1')
+    # Production-ready server configuration for Render
+    host = os.environ.get('HOST', '0.0.0.0')
     port = int(os.environ.get('PORT', 5000))
-    debug = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
+    debug = os.environ.get('FLASK_DEBUG', 'False').lower() in ['true', '1', 'yes']
     
     print(f"🏀 NBA Analytics Suite starting on {host}:{port}")
     print(f"📊 Debug mode: {debug}")

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: nba-analytics-suite
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn --bind 0.0.0.0:$PORT app:app --workers 2 --timeout 60
+    envVars:
+      - key: FLASK_DEBUG
+        value: "false"
+      - key: FLASK_ENV
+        value: "production"
+    healthCheckPath: / 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib==3.7.2
 seaborn==0.12.2
 pandas==2.1.0
 numpy==1.24.3
+gunicorn==21.2.0


### PR DESCRIPTION
## 🐛 Problem
The deployment on Render was failing with the error:
```
Port scan timeout reached, no open ports detected on 0.0.0.0
Detected open ports on localhost -- did you mean to bind one of these to 0.0.0.0?
```

This happens because the Flask app was binding to `127.0.0.1` (localhost) instead of `0.0.0.0`, preventing Render from detecting that the service is up and running.

## ✅ Solution
1. **Fixed Flask binding**: Changed default host from `127.0.0.1` to `0.0.0.0` in `app.py`
2. **Added production configuration**: Created `render.yaml` with proper deployment settings
3. **Added Gunicorn**: Updated `requirements.txt` to include gunicorn for production server
4. **Optimized for Render**: Configured gunicorn with appropriate workers and timeout settings
5. **Improved environment handling**: Enhanced debug flag parsing and added production environment variables

## 🔄 Changes Made
- **app.py**: Changed host binding from localhost to 0.0.0.0 for Render compatibility
- **requirements.txt**: Added `gunicorn==21.2.0` for production WSGI server
- **render.yaml**: New configuration file with proper deployment settings

## 🚀 Expected Result
- Render should now properly detect the open port
- Deployment should complete successfully
- App should be accessible at https://nba-analytics-suite.onrender.com

## 🧪 Testing
After merging, the Render service should automatically redeploy and work correctly. The deployment logs should show successful port binding and no timeout errors.

Fixes the deployment timeout issue reported in the Render dashboard.