### PR TITLE
🐛 Fix SeasonManager method call causing startup error

### DIFF
--- a/app.py
+++ b/app.py
@@ -292,7 +292,7 @@ def index():
     """Main dashboard with all analytics tools"""
     try:
         # Update seasons on each request
-        season_manager.update_seasons()
+        season_manager.add_new_season_if_needed()
         return render_template('index.html')
     except Exception as e:
         # Fallback for deployment issues


### PR DESCRIPTION
## 🐛 Problem
The deployment on Render was showing the error:
```
Error: 'SeasonManager' object has no attribute 'update_seasons'
```

This was preventing the main dashboard from loading properly, even though the health check endpoint was working.

## 🔍 Root Cause
The code in the index route was calling `season_manager.update_seasons()`, but the `SeasonManager` class doesn't have an `update_seasons()` method. Instead, it has an `add_new_season_if_needed()` method.

## ✅ Solution
- Changed `season_manager.update_seasons()` to `season_manager.add_new_season_if_needed()` in the index route
- This matches the actual method name in the `SeasonManager` class implementation
- Verified that this method is used correctly elsewhere in the codebase

## 🧪 Testing
- Health check endpoint confirms service is running: `{"status":"healthy","message":"NBA Analytics Suite is running"}`
- Fix addresses the specific AttributeError that was blocking dashboard loading
- Method name now matches the actual class implementation

## 📝 Changes
- **app.py**: Line 294 - Corrected method call from `update_seasons()` to `add_new_season_if_needed()`

This should resolve the startup error and allow the main dashboard to load properly on Render.